### PR TITLE
FS: defect fix: compare expression was always false

### DIFF
--- a/filter/src/main/java/com/bhs/gtk/filter/persistence/EntityReader.java
+++ b/filter/src/main/java/com/bhs/gtk/filter/persistence/EntityReader.java
@@ -79,7 +79,7 @@ public class EntityReader {
 			return arResults;
 		}
 		arResults.add(leftResult);
-		arResults.add(leftResult);
+		arResults.add(rightResult);
 		return arResults;
 	}
 	


### PR DESCRIPTION
Root cause was the list holding ar exps of given compare expression was
wrongly added only left exp two times.
The issue fixed by adding left and right expression in to the list.